### PR TITLE
Check for endpoint['grade'] before dereferencing

### DIFF
--- a/test.py
+++ b/test.py
@@ -46,8 +46,10 @@ def analyseResult(result, mingrade, mindaysremaining):
 
     print(result['host'] + ', expires in ' + str(daysRemaining) + ' days')
     for endpoint in result['endpoints']:
-        grade = endpoint['grade']
-        if grades.index(grade) > minGradeIndex:
+        grade = endpoint['grade'] if 'grade' in endpoint else None
+        if grade is None:
+            print('ERROR: Endpoint has no "grade" field: ' + endpoint)
+        if grade is None or grades.index(grade) > minGradeIndex:
             isOk = False
         print(' - ' + endpoint['serverName'] + ' (' + endpoint['ipAddress'] + ') => ' + grade)
     print()

--- a/test.py
+++ b/test.py
@@ -48,7 +48,8 @@ def analyseResult(result, mingrade, mindaysremaining):
     for endpoint in result['endpoints']:
         grade = endpoint['grade'] if 'grade' in endpoint else None
         if grade is None:
-            print('ERROR: Endpoint has no "grade" field: ' + endpoint)
+            print('ERROR: Endpoint has no "grade" field')
+            print(endpoint)
         if grade is None or grades.index(grade) > minGradeIndex:
             isOk = False
         print(' - ' + endpoint['serverName'] + ' (' + endpoint['ipAddress'] + ') => ' + grade)


### PR DESCRIPTION
The program sometimes crashes because of an invalid dict deref. This PR introduces a check before the deref and prints diagnostics if that deref fails